### PR TITLE
Fixed Issue with WeepingAngel Arm Poses

### DIFF
--- a/src/angel/WeepingAngelManager.kt
+++ b/src/angel/WeepingAngelManager.kt
@@ -83,10 +83,17 @@ class WeepingAngelManager(
       getAngelInLineOfSight(getAllAngels(), entity)
 
     fun assignIdlePose(angel: ArmorStand) {
-      // left: -130, 50, 10
-      // right: -130, -50, -10
-      angel.setLeftArmPose(EulerAngle(2.269, -0.873, 0.175))
-      angel.setRightArmPose(EulerAngle(2.269, 0.873, -0.175))
+      /*
+      left: -130, 50, 10
+      right: -130, -50, -10
+      summon command uses degrees, Eulers use Radians, so we convert degrees to radians
+      -2.26893 0.872665 0.174533
+      -2.26893 -0.872665 -0.174533
+      Hey guess what? Turns out those - signs, THEY ARE IMPORTANT KEEP THEM
+      */
+      angel.setLeftArmPose(EulerAngle(-2.26893, 0.872665, 0.174533))
+      angel.setRightArmPose(EulerAngle(-2.26893, -0.872665, -0.174533))
+      //The above radians are correct DO NOT TOUCH THEM OR I SWEAR TO GOD
     }
 
     fun assignAttackPose(angel: ArmorStand) {


### PR DESCRIPTION
fix for #32  

Fine. I'll Fix it myself. And I DID!
Don't touch them!

Minecraft uses degrees, so we convert those to radians, WE KEEP THE NEGATIVE VALUES
we also keep the floating point data because the compiler will take care of it for us, and if we round them it will make the angels off by a lot more then we think

Here's a pic of them working in action
![fixed](https://user-images.githubusercontent.com/61751485/140830691-7889a43f-788f-443b-8625-cb8cf122079d.png)


