### PR TITLE
Fix for phantom fire

### DIFF
--- a/src/PetPhantomManager.kt
+++ b/src/PetPhantomManager.kt
@@ -78,23 +78,21 @@ class PetPhantomManager(
   }
 
   @EventHandler
-  fun onEntityDamage(event: EntityDamageEvent) {
-    if (!isEnabled()) {
-      return
-    }
+  fun onEntityDamage(event: EntityCombustEvent) {
+    if (event.isCancelled()) return
 
     val entity = event.getEntity()
 
     // Protect phantoms from fire
     if (entity is Phantom) {
       if (knownPhantoms.containsValue(entity)) {
-        if ((event.getCause() == EntityDamageEvent.DamageCause.FIRE) || (event.getCause() == EntityDamageEvent.DamageCause.FIRE_TICK)) {
           event.setCancelled(true)
-        }
+          entity.setFireTicks(0)
       }
     }
 
   }
+
 
   private fun spawnPhantom(player: Player): Phantom? {
     val loc = player.location.clone()


### PR DESCRIPTION
So you know how Vector burns but doesnt take damage??

Well this will hopefully prevent him from being on fire in the first place

Tested it in my plugin and it works, but because I dont use kotlin and dont have your build setup, I have this untested

The EntityCombustEvent fires when an entity is on fire
so we just cancel the event, then set the next tick to put out vector's fire

so Vector never gets a chance to burn and take damage 